### PR TITLE
Update parserOptions in eslint base config

### DIFF
--- a/eslint-configs/javascript/index.js
+++ b/eslint-configs/javascript/index.js
@@ -1,3 +1,7 @@
 module.exports = {
-  extends: ["eslint:recommended", "plugin:prettier/recommended"]
+  extends: ["eslint:recommended", "plugin:prettier/recommended"],
+  // define parser options to make features such as async/wait work
+  parserOptions: {
+    ecmaVersion: 2020 // same as ECMAScript 10
+  }
 };

--- a/eslint-configs/javascript/package.json
+++ b/eslint-configs/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-js",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "base javascript eslint config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/eslint-configs/javascript/package.json
+++ b/eslint-configs/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-js",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "base javascript eslint config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/eslint-configs/javascript/package.json
+++ b/eslint-configs/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-js",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "description": "base javascript eslint config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/eslint-configs/typescript-react/package.json
+++ b/eslint-configs/typescript-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts-react",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "typescript-react eslint config for the kwiz organization",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "Alex Scheitlin <alex.scheitlin@uzh.ch>"
   ],
   "dependencies": {
-    "@kwizapp/eslint-config-ts": "^0.0.6"
+    "@kwizapp/eslint-config-ts": "^0.0.7"
   },
   "peerDependencies": {
     "eslint-plugin-react": ">=7.17.0 <8"

--- a/eslint-configs/typescript-react/package.json
+++ b/eslint-configs/typescript-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts-react",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "typescript-react eslint config for the kwiz organization",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "Alex Scheitlin <alex.scheitlin@uzh.ch>"
   ],
   "dependencies": {
-    "@kwizapp/eslint-config-ts": "^0.0.7"
+    "@kwizapp/eslint-config-ts": "^0.0.8"
   },
   "peerDependencies": {
     "eslint-plugin-react": ">=7.17.0 <8"

--- a/eslint-configs/typescript/package.json
+++ b/eslint-configs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "typescript eslint config for the kwiz organization",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "Alex Scheitlin <alex.scheitlin@uzh.ch>"
   ],
   "dependencies": {
-    "@kwizapp/eslint-config-js": "^0.0.7"
+    "@kwizapp/eslint-config-js": "^0.0.8"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">= 2",

--- a/eslint-configs/typescript/package.json
+++ b/eslint-configs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "typescript eslint config for the kwiz organization",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "Alex Scheitlin <alex.scheitlin@uzh.ch>"
   ],
   "dependencies": {
-    "@kwizapp/eslint-config-js": "^0.0.3"
+    "@kwizapp/eslint-config-js": "^0.0.7"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">= 2",

--- a/prettier-config/package.json
+++ b/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/prettier-config",
-  "version": "0.0.3",
+  "version": "0.0.8",
   "description": "prettier config for the kwiz organization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

When pulling in the base javascript version, eslint couldn't lint the modern features properly such as `async/wait`. Therefore I've added a `paserOptions` key in the base javascript config.

Also bumped the version of all packages to `v0.0.8`.

Hopefully this will make it easier in the future when we use lerna. (#5)

### Related Issues

Issue #8 

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this PR?
