### PR TITLE
Fix: Disable member-delimiter-style as it conflicts with prettier

### DIFF
--- a/eslint-configs/javascript/package.json
+++ b/eslint-configs/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-js",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "base javascript eslint config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/eslint-configs/javascript/package.json
+++ b/eslint-configs/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-js",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "base javascript eslint config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/eslint-configs/typescript-react/package.json
+++ b/eslint-configs/typescript-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts-react",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "typescript-react eslint config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/eslint-configs/typescript-react/package.json
+++ b/eslint-configs/typescript-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts-react",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "typescript-react eslint config for the kwiz organization",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "Alex Scheitlin <alex.scheitlin@uzh.ch>"
   ],
   "dependencies": {
-    "@kwizapp/eslint-config-ts": "^0.0.8"
+    "@kwizapp/eslint-config-ts": "^0.0.10"
   },
   "peerDependencies": {
     "eslint-plugin-react": ">=7.17.0 <8"

--- a/eslint-configs/typescript/index.js
+++ b/eslint-configs/typescript/index.js
@@ -9,6 +9,7 @@ module.exports = {
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": "error"
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/member-delimiter-style": "off"
   }
 };

--- a/eslint-configs/typescript/package.json
+++ b/eslint-configs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "typescript eslint config for the kwiz organization",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "Alex Scheitlin <alex.scheitlin@uzh.ch>"
   ],
   "dependencies": {
-    "@kwizapp/eslint-config-js": "^0.0.8"
+    "@kwizapp/eslint-config-js": "^0.0.10"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">= 2",

--- a/eslint-configs/typescript/package.json
+++ b/eslint-configs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/eslint-config-ts",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "typescript eslint config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/prettier-config/package.json
+++ b/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/prettier-config",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "prettier config for the kwiz organization",
   "repository": {
     "type": "git",

--- a/prettier-config/package.json
+++ b/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwizapp/prettier-config",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "prettier config for the kwiz organization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Disable member-delimiter-style as it conflicts with prettier.

It is generally an issue that prettier is already imported in the JS base eslint config, as it should normally be placed last (it overrides some problematic stuff from other configs such that conflicts are prevented). This could cause problems similar to this one.